### PR TITLE
Tested in devel branch: tsmtapehints.pl, JSON for tape hints, better signal handling, remove use of IPC::Run3, etc

### DIFF
--- a/Endit.pm
+++ b/Endit.pm
@@ -174,8 +174,8 @@ my %confitems = (
 		desc => "When in concurrent mode, don't remount tapes more often than this, seconds",
 	},
 	retriever_hintfile => {
-		example => "/var/spool/endit/tapehints/EXAMPLENODE.txt",
-		desc => "Tape hints file for concurrent dsmc retrievers. Generate using\ntsm_getvolumecontent.pl for the -asnode user you configured in dsmcopts",
+		example => "/var/spool/endit/tapehints/EXAMPLENODE.json",
+		desc => "Tape hints file for concurrent dsmc retrievers. Generate by\nperiodically running either tsmtapehintspl (on node running ENDIT) or\ntsm_getvolumecontent.pl (requires TSM server credentials) for the\n-asnode user you configured in dsmcopts",
 	},
 	retriever_reqlistfillwait => {
 		default => 600,
@@ -340,22 +340,6 @@ sub getusage($@) {
 	printlog "Total size: $size bytes" if($conf{debug});
 
 	return $size/(1024*1024*1024); # GiB
-}
-
-sub readtapelist($) {
-	my $tapefile = shift;
-	printlog "reading tape list $tapefile" if $conf{verbose};
-	my $out = {};
-	open my $tf, '<', $tapefile or return undef;
-	while (<$tf>) {
-		chomp;
-		my ($id,$tape) = split /\s+/;
-		next unless defined $id && defined $tape;
-		$tape=~tr/a-zA-Z0-9.-/_/cs;
-		$out->{$id} = $tape;
-	}
-	close($tf);
-	return $out;
 }
 
 1;

--- a/Endit.pm
+++ b/Endit.pm
@@ -175,7 +175,7 @@ my %confitems = (
 	},
 	retriever_hintfile => {
 		example => "/var/spool/endit/tapehints/EXAMPLENODE.json",
-		desc => "Tape hints file for concurrent dsmc retrievers. Generate by\nperiodically running either tsmtapehintspl (on node running ENDIT) or\ntsm_getvolumecontent.pl (requires TSM server credentials) for the\n-asnode user you configured in dsmcopts",
+		desc => "Tape hints file for concurrent dsmc retrievers. Generate by\nperiodically running either tsmtapehints.pl (on node running ENDIT) or\ntsm_getvolumecontent.pl (requires TSM server credentials) for the\n-asnode user you configured in dsmcopts",
 	},
 	retriever_reqlistfillwait => {
 		default => 600,

--- a/Endit.pm
+++ b/Endit.pm
@@ -17,7 +17,6 @@
 package Endit;
 use strict;
 use warnings;
-use IPC::Run3;
 use POSIX qw(strftime);
 use File::Temp qw /tempfile/;
 use File::Basename;

--- a/Endit.pm
+++ b/Endit.pm
@@ -110,6 +110,12 @@ my %confitems = (
 		example => '-asnode=EXAMPLENODE, -errorlogname=/var/log/dcache/dsmerror.log',
 		desc => 'Base options to dsmc, ", "-delimited list',
 	},
+	dsmc_displayopts => {
+		default => '-dateformat=3, -timeformat=1, -numberformat=1',
+		# dsmc display options, not intended to be modified by users.
+		# Used for all commands except archive.
+		# ", "-delimited list.
+	},
 	sleeptime => {
 		default => 60,
 		desc => 'Sleep for this many seconds between each cycle',

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ ENDIT is comprised of an ENDIT dCache plugin and the ENDIT daemons.
 
 # Requirements
 
-At least the following Perl modules need to be installed:
+At least the following Perl module need to be installed:
 
-* JSON, IPC::Run3
+* JSON
 
 It is known to work on Perl >= 5.14, but notably 5.10 does not work.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Benefits:
 * Easier to set up:
   * Uses the ENDIT configuration file
   * Only needs periodic invocation (crontab, systemd timer)
+* Performs some sanity checking, in particular detection of duplicates
+  of archived files (multiple tape copies of the same file object)
 
 Drawbacks:
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Benefits:
 Drawbacks:
 
 * More cumbersome to set up:
-** Requires dsmadmc
-** Requires close cooperation with TSM server admins due to admin user etc.
-** Requires TSM admin user password in a clear-text file
+  * Requires dsmadmc
+  * Requires close cooperation with TSM server admins due to admin user etc.
+  * Requires TSM admin user password in a clear-text file
 
 ### tsmtapehints.pl
 
@@ -124,8 +124,8 @@ information.
 Benefits:
 
 * Easier to set up:
-** Uses the ENDIT configuration file
-** Only needs periodic invocation (crontab, systemd timer)
+  * Uses the ENDIT configuration file
+  * Only needs periodic invocation (crontab, systemd timer)
 
 Drawbacks:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,67 @@ After starting dcache you also need to start the three scripts:
 
 See [startup/README.md](startup/README.md) for details/examples.
 
+To enable concurrent retrieves from multiple tapes you must use a tape hint
+file, a file that provides info on which tape volume files are stored.
+
+## Tape hint file
+
+The tape hint file name to be loaded by tsmretriever.pl is set using the
+retriever_hintfile specifier in the configuration file.
+
+This file can be generated either from the TSM server side or from the
+TSM client side using one of the provided scripts. Choose the one that
+works best in your environment.
+
+In general we recommend to run only one script per TSM proxy node name
+and distribute the resulting file to all affected hosts running ENDIT.
+Running multiple scripts works, but may put unnecessary strain on your
+TSM server database.
+
+Updating the file by running the script daily is recommended.
+
+### tsm_getvolumecontent.pl
+
+This method communicates with the TSM server. It has the following
+requirements:
+
+* The dsmadmc utility set up to communicate properly with the TSM
+  server.
+* A TSM server administrative user (no extra privilege needed).
+
+Benefits:
+
+* Volume names are the real tape volume names as used by TSM
+* Tests have shown this method to be approximately a factor 2 faster
+  than using tsmtapehints.pl
+
+Drawbacks:
+
+* More cumbersome to set up:
+** Requires dsmadmc
+** Requires close cooperation with TSM server admins due to admin user etc.
+** Requires TSM admin user password in a clear-text file
+
+### tsmtapehints.pl
+
+This method runs together with the other ENDIT daemons and uses the dsmc
+command as specified by the ENDIT configuration file to list file
+information.
+
+Benefits:
+
+* Easier to set up:
+** Uses the ENDIT configuration file
+** Only needs periodic invocation (crontab, systemd timer)
+
+Drawbacks:
+
+* Volume names are numeric IDs, good enough to group files correctly but
+  not easily usable by a TSM admin to identify a specific tape volume in case
+  of issues.
+* Slower, tests have shown a factor of 2 slowdown compared to
+  tsm_getvolumecontents.pl
+
 # Multiple instances
 
 To run multiple instances, the ENDIT_CONFIG environment variable can be set

--- a/tsm_getvolumecontent.pl
+++ b/tsm_getvolumecontent.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/perl
 
 #   tsm_getvolumecontent.pl - helper script to show tsm tape contents
 #   Copyright (C) 2012-2017 <Niklas.Edmundsson@hpc2n.umu.se>

--- a/tsm_getvolumecontent.pl
+++ b/tsm_getvolumecontent.pl
@@ -21,6 +21,8 @@
 use warnings;
 use strict;
 
+use JSON;
+use File::Temp qw /tempfile/;
 use Getopt::Std;
 use File::Basename;
 
@@ -110,6 +112,7 @@ my %files;
 foreach my $volume (@volumes) {
     debug "Getting content of volume $volume ...";
     my @t=dsm_cmd("q content $volume node=$opts{N} f=d") or die "Failed to query content on $volume";
+    my $seqid = 0;
     foreach my $line (@t) {
         my($nodename, $type, $fsname, $hexfsname, $fsid, $filename, $hexfilename, $isaggr, $size, $segment, $cached) = split (/\t/, $line);
 
@@ -125,21 +128,23 @@ foreach my $volume (@volumes) {
         else {
             $filename =~ s!.*/!!;
         }
-        $files{$filename} = $volume;
+        $files{$filename}{volid} = $volume;
+        $files{$filename}{order} = $seqid++; # Assumes q content outputs items in tape order
     }
     debug " Found " . scalar @t . " entries";
 }
 
 debug "Finished, total " . scalar (keys %files) . " entries";
 
-my $tmpf = "$opts{f}.$$"; # Assume we're alone in the destdir
+my $tmpfh = File::Temp->new(TEMPLATE => "$opts{f}.XXXXXX");
+my $tmpf = $tmpfh->filename;
+
 debug "Writing volume contents to file $tmpf";
-open(my $fh, '>', $tmpf) || die "Unable to open $opts{f}: $!";
-my($key,$value);
-while (($key,$value) = each %files) {
-    print $fh "$key\t$value\n" || die "Writing $opts{f}: $!";
-}
-close $fh || die "Closing $tmpf: $!";
+print $tmpfh encode_json(\%files),"\n";
+
+$tmpfh->unlink_on_destroy(0);
+close $tmpfh || die "Closing $tmpf: $!";
+
 debug "Done. Renaming $tmpf to $opts{f}";
 rename($tmpf, $opts{f}) || die "Rename $tmpf to $opts{f}: $!";
 

--- a/tsmarchiver.pl
+++ b/tsmarchiver.pl
@@ -125,8 +125,9 @@ while(1) {
 		printlog "Adding ${triggerthreshold}_dsmcopts " . $conf{"${triggerthreshold}_dsmcopts"} if($conf{debug});
 		push @dsmcopts, split(/, /, $conf{"${triggerthreshold}_dsmcopts"});
 	}
+	my $date=strftime("%Y-%m",localtime());
 	my @cmd = ('dsmc','archive','-deletefiles', @dsmcopts,
-		"-description=endit","-filelist=$fn");
+		"-description=endit-$date","-filelist=$fn");
 	printlog "Executing: " . join(" ", @cmd) if($conf{debug});
 	my $execstart = time();
 	my ($out,$err);

--- a/tsmarchiver.pl
+++ b/tsmarchiver.pl
@@ -125,9 +125,9 @@ while(1) {
 		printlog "Adding ${triggerthreshold}_dsmcopts " . $conf{"${triggerthreshold}_dsmcopts"} if($conf{debug});
 		push @dsmcopts, split(/, /, $conf{"${triggerthreshold}_dsmcopts"});
 	}
-	my $date=strftime("%Y-%m",localtime());
+	my $now=strftime("%Y-%m-%dT%H:%M:%S%z",localtime());
 	my @cmd = ('dsmc','archive','-deletefiles', @dsmcopts,
-		"-description=endit-$date","-filelist=$fn");
+		"-description=ENDIT-$now","-filelist=$fn");
 	printlog "Executing: " . join(" ", @cmd) if($conf{debug});
 	my $execstart = time();
 	my ($out,$err);

--- a/tsmarchiver.pl
+++ b/tsmarchiver.pl
@@ -171,7 +171,7 @@ while(1) {
 			       ($? & 127),  ($? & 128) ? 'with' : 'without';
 		}
 		else {
-			$msg .= sprintf "dsmc exited with value %d\n", $? >> 8;
+			$msg .= sprintf "dsmc exited with value %d", $? >> 8;
 		}
 		printlog "$msg";
 

--- a/tsmarchiver.pl
+++ b/tsmarchiver.pl
@@ -116,7 +116,7 @@ while(1) {
 	print $fh map { "$conf{'dir'}/out/$_\n"; } @files;
 	close($fh) || die "Failed writing to $fn: $!";
 
-	my @dsmcopts = split /, /, $conf{'dsmcopts'};
+	my @dsmcopts = split(/, /, $conf{'dsmcopts'});
 	if(!$triggerthreshold && $conf{archiver_timeout_dsmcopts}) {
 		printlog "Adding archiver_timeout_dsmcopts " . $conf{archiver_timeout_dsmcopts} if($conf{debug});
 		push @dsmcopts, split(/, /, $conf{archiver_timeout_dsmcopts});

--- a/tsmarchiver.pl
+++ b/tsmarchiver.pl
@@ -30,6 +30,9 @@ use Endit qw(%conf readconf printlog getusage);
 
 $Endit::logsuffix = 'tsmarchiver.log';
 
+# Turn off output buffering
+$| = 1;
+
 readconf();
 
 my $filelist = "tsm-archive-files.XXXXXX";

--- a/tsmdeleter.pl
+++ b/tsmdeleter.pl
@@ -99,7 +99,8 @@ sub rundelete {
 	my $filelist=shift;
 	my $reallybroken=0;
 	my($out, $err);
-	my @dsmcopts = split /, /, $conf{'dsmcopts'};
+	my @dsmcopts = split(/, /, $conf{'dsmc_displayopts'});
+	push @dsmcopts, split(/, /, $conf{'dsmcopts'});
 	my @cmd = ('dsmc','delete','archive','-noprompt',
 		@dsmcopts,"-filelist=$filelist");
         printlog "Executing: " . join(" ", @cmd) if($conf{debug});

--- a/tsmdeleter.pl
+++ b/tsmdeleter.pl
@@ -159,7 +159,7 @@ sub rundelete {
 				$msg .= sprintf "child died with signal %d, %s coredump", ($? & 127),  ($? & 128) ? 'with' : 'without';
 			}
 			else {
-				$msg .= sprintf "child exited with value %d\n", $? >> 8;
+				$msg .= sprintf "child exited with value %d", $? >> 8;
 			}
 			printlog "$msg";
 			if($conf{verbose}) {

--- a/tsmdeleter.pl
+++ b/tsmdeleter.pl
@@ -29,6 +29,9 @@ use Endit qw(%conf readconf printlog getusage);
 
 $Endit::logsuffix = 'tsmdeleter.log';
 
+# Turn off output buffering
+$| = 1;
+
 readconf();
 
 my $filelist = "tsm-delete-files.XXXXXX";

--- a/tsmdeleter.pl
+++ b/tsmdeleter.pl
@@ -193,7 +193,14 @@ while(1) {
 		my ($fh, $filename) = tempfile($filelist, DIR=>$conf{'dir'}, UNLINK=>$dounlink);
 		print $fh map { "$conf{'dir'}/out/$_\n"; } @files;
 		close($fh) || die "Failed writing to $filename: $!";
-		printlog "Trying to delete " . scalar(@files) . " files from file list $filename";
+
+		my $logstr = "Trying to delete " . scalar(@files) . " files from file list $filename";
+		if($conf{verbose}) {
+			$logstr .= " (files: " . join(" ", @files) . ")";
+		}
+		printlog $logstr;
+		$logstr = undef;
+
 		if(rundelete($filename)) {
 			# Have already warned in rundelete()
 		} else {

--- a/tsmretriever.pl
+++ b/tsmretriever.pl
@@ -33,8 +33,6 @@ $Endit::logsuffix = 'tsmretriever.log';
 
 readconf();
 
-my $listfilecounter = 0;
-
 # Try to send warn/die messages to log file
 INIT {
         $SIG{__DIE__}=sub {

--- a/tsmretriever.pl
+++ b/tsmretriever.pl
@@ -30,6 +30,9 @@ use Endit qw(%conf readconf printlog getusage);
 
 $Endit::logsuffix = 'tsmretriever.log';
 
+# Turn off output buffering
+$| = 1;
+
 readconf();
 
 # Try to send warn/die messages to log file

--- a/tsmretriever.pl
+++ b/tsmretriever.pl
@@ -349,7 +349,8 @@ while(1) {
 				printlog "Trying to retrieve files from volume $tape using file list $listfile";
 
 				my $indir = $conf{dir} . '/in/';
-				my @dsmcopts = split /, /, $conf{'dsmcopts'};
+				my @dsmcopts = split(/, /, $conf{'dsmc_displayopts'});
+				push @dsmcopts, split(/, /, $conf{'dsmcopts'});
 				my @cmd = ('dsmc','retrieve','-replace=no','-followsymbolic=yes',@dsmcopts, "-filelist=$listfile",$indir);
 				printlog "Executing: " . join(" ", @cmd) if($conf{debug});
 				my $execstart = time();

--- a/tsmtapehints.pl
+++ b/tsmtapehints.pl
@@ -1,0 +1,219 @@
+#!/usr/bin/perl
+
+#   ENDIT - Efficient Northern Dcache Interface to TSM
+#   Copyright (C) 2018 <Niklas.Edmundsson@hpc2n.umu.se>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use warnings;
+use strict;
+
+use POSIX qw(strftime);
+use JSON;
+use File::Temp qw /tempfile/;
+use File::Basename;
+
+# Add directory of script to module search path
+use lib dirname (__FILE__);
+use Endit qw(%conf readconf printlog getusage);
+
+$Endit::logsuffix = 'tsmtapehints.log';
+
+readconf();
+
+# Try to send warn/die messages to log file
+INIT {
+        $SIG{__DIE__}=sub {
+                printlog("DIE: $_[0]");
+        };
+
+        $SIG{__WARN__}=sub {
+                print STDERR "$_[0]";
+                printlog("WARN: $_[0]");
+        };
+}
+
+$SIG{INT} = sub { printlog("Got SIGINT, exiting..."); exit; };
+$SIG{QUIT} = sub { printlog("Got SIGQUIT, exiting..."); exit; };
+$SIG{TERM} = sub { printlog("Got SIGTERM, exiting..."); exit; };
+
+my $desclong="";
+if($conf{'desc-long'}) {
+	$desclong = " $conf{'desc-long'}";
+}
+printlog("$0: Starting$desclong...");
+
+if (!exists $conf{retriever_hintfile}) {
+	die "retriever_hintfile not configured, nothing to do!";
+}
+
+my $hintfile = $conf{retriever_hintfile};
+
+my $hftmp = File::Temp->new(TEMPLATE => "$hintfile.XXXXXX");
+my $hintfiletmp = $hftmp->filename;
+
+my @dsmcopts = split(/, /, $conf{'dsmc_displayopts'});
+push @dsmcopts, split(/, /, $conf{'dsmcopts'});
+my $outdir = "$conf{dir}/out";
+my @cmd = ('dsmc','query','archive','-filesonly','-detail',@dsmcopts,"$outdir/*");
+
+printlog "Executing: " . join(" ", @cmd) if($conf{debug});
+
+open(my $dsmcfh, "-|", @cmd) || die "can't start dsmc: $!";
+
+my %tapelist;
+
+# ==============
+# Example output
+# --------------
+# IBM Spectrum Protect
+# Command Line Backup-Archive Client Interface
+#   Client Version 8, Release 1, Level 4.1 
+#   Client date/time: 2018-06-01 15:39:04
+# (c) Copyright by IBM Corporation and other(s) 1990, 2018. All Rights Reserved. 
+# 
+# Node Name: NODENAME
+# Session established with server SERVERNAME: Linux/x86_64
+#   Server Version 8, Release 1, Level 5.000
+#   Server date/time: 2018-06-01 15:39:04  Last access: 2018-06-01 15:37:56
+# 
+# Accessing as node: ASNODENAME
+#              Size  Archive Date - Time    File - Expires on - Description
+#              ----  -------------------    -------------------------------
+#         72,191  B  2016-04-01 02:17:31    /grid/pool/out/0000004C9A19B5FA480398AED8A6CD61107D Never endit  RetInit:STARTED  ObjHeld:NO
+#          Modified: 2016-04-01 01:52:11  Accessed: 2016-04-01 01:05:51  Inode changed: 2016-04-01 01:59:24
+#          Compression Type: None  Encryption Type:        None  Client-deduplicated: NO
+#   Media Class: Library  Volume ID: 724216  Restore Order: 00000000-00000002-00000000-00CEF5A1
+# --------------
+
+my ($lastfile, $size, $timestamp);
+my %hints;
+
+my @errmsgs;
+
+while(<$dsmcfh>) {
+	chomp;
+
+	# Catch error messages, only printed on non-zero return code from dsmc
+	if(/^AN\w\d\d\d\d\w/) {
+		push @errmsgs, $_;
+		next;
+	}
+	# Match a line with a file name, save the useful info.
+	# We assume that our file name doesn't contain a space character!
+	elsif(m!^\s*([\d,]+)\s+(\S+)\s+(\d\d\d\d-\d\d-\d\d\s+\d\d:\d\d:\d\d)\s+$outdir/(\S+)\s+(\S+)!)
+	{
+		$size = $1;
+		my $sizeunit = $2;
+		$timestamp = $3;
+		$lastfile = $4;
+		my $expire = $5;
+
+		if($sizeunit eq 'B') {
+			$size =~ s/,//g;
+		}
+		else {
+			$size = undef;
+		}
+
+		if($expire ne 'Never') {
+			warn "File $lastfile will expire on $expire";
+		}
+		next;
+	}
+	elsif(!defined($lastfile)) {
+		next;
+	}
+	# Match a line with a Volume ID and Restore Order.
+	elsif(/Volume\sID:\s+(\d+).*Restore\sOrder:\s+(\S+)/) {
+		my $volid = $1;
+		my $restorder = $2;
+
+		if($hints{$lastfile}) {
+			if(!defined($hints{$lastfile}{duplicates})) {
+				$hints{$lastfile}{duplicates} = 0;
+			}
+			$hints{$lastfile}{duplicates} ++;
+			if($size && $hints{$lastfile}{size} && $size != $hints{$lastfile}{size})
+			{
+				$hints{$lastfile}{duplicatesizemismatch} = 1;
+			}
+		}
+		else {
+			$hints{$lastfile}{volid} = $volid;
+			$hints{$lastfile}{order} = $restorder;
+			$hints{$lastfile}{timestamp} = $timestamp;
+			if(defined($size)) {
+				$hints{$lastfile}{size} = $size;
+			}
+		}
+
+		$lastfile = undef;
+	}
+}
+
+if(!close($dsmcfh) && $!) {
+	die "closing pipe from dsmc: $!";
+}
+elsif($? != 0) {
+	my $msg = "dsmc query archive failure: ";
+	if ($? == -1) {
+		$msg .= "failed to execute: $!";
+	}
+	elsif ($? & 127) {
+		$msg .= sprintf "dsmc died with signal %d, %s coredump", ($? & 127),  ($? & 128) ? 'with' : 'without';
+	}
+	else {
+		$msg .= sprintf "dsmc exited with value %d", $? >> 8;
+	}
+	foreach my $errmsg (@errmsgs) {
+		warn "dsmc error message: $errmsg";
+	}
+
+	die "$msg, aborting...";
+}
+
+my $dupfiles = 0;
+my $dupcount = 0;
+while(my($k, $v) = each %hints) {
+	if($v->{duplicates}) {
+		$dupfiles ++;
+		$dupcount += $v->{duplicates};
+		my $s = "File $k has $v->{duplicates} duplicates";
+		if($v->{duplicatesizemismatch}) {
+			$s .= ", some with different size";
+			delete($v->{duplicatesizemismatch});
+		}
+		warn $s;
+		delete($v->{duplicates});
+	}
+
+	if(defined($v->{size})) {
+		delete($v->{size});
+	}
+	if(defined($v->{timestamp})) {
+		delete($v->{timestamp});
+	}
+}
+
+if($dupfiles) {
+	warn "$dupfiles files with total $dupcount duplicates";
+}
+
+print $hftmp encode_json(\%hints),"\n";
+
+$hftmp->unlink_on_destroy(0);
+close($hftmp) || die "Writing $hintfiletmp: $!";
+rename($hintfiletmp, $hintfile) || die "rename $hintfiletmp $hintfile: $!";
+printlog "$hintfile updated (" . scalar(keys %hints) . " hints)";

--- a/tsmtapehints.pl
+++ b/tsmtapehints.pl
@@ -30,6 +30,9 @@ use Endit qw(%conf readconf printlog getusage);
 
 $Endit::logsuffix = 'tsmtapehints.log';
 
+# Turn off output buffering
+$| = 1;
+
 readconf();
 
 # Try to send warn/die messages to log file


### PR DESCRIPTION
Merge changes tested in devel branch.

Highlights are:
- tsmtapehints.pl - create tape hint files on client (requires later version dsmc)
- Use JSON format for tape hints - allows extending/adding info later on
- Better signal handling - now also kills any children (ie. dsmc) instead of relying on systemd or similar
- Remove use of IPC::Run3 - use another workaround for aborting dsmc if it wants to prompt unexpectedly
- Detect incomplete retrieved files - now checks for offending incomplete files in in/ directory and clean as appropriate
- Revert to use a more useful description of archived files - since TSM v6 the DB does not have the same limitations, now each session gets logged with an ISO style date/time in description
